### PR TITLE
Improve ship config dump mapping

### DIFF
--- a/Nodsoft.WowsReplaysUnpack/CamouflageInfo.cs
+++ b/Nodsoft.WowsReplaysUnpack/CamouflageInfo.cs
@@ -5,14 +5,13 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Nodsoft.WowsReplaysUnpack
+namespace Nodsoft.WowsReplaysUnpack;
+
+internal class CamouflageInfo : IObjectConstructor
 {
-	internal class CamouflageInfo : IObjectConstructor
+	public object construct(object[] args)
 	{
-		public object construct(object[] args)
-		{
-			//Console.WriteLine("{0}, {1}", args);
-			return string.Format("{0}, {1}", args);
-		}
+		//Console.WriteLine("{0}, {1}", args);
+		return string.Format("{0}, {1}", args);
 	}
 }

--- a/Nodsoft.WowsReplaysUnpack/Constants.cs
+++ b/Nodsoft.WowsReplaysUnpack/Constants.cs
@@ -51,4 +51,20 @@ internal static class Constants
 		public const byte OnChatMessage = 122;
 		public const byte OnArenaStatesReceived = 124;
 	}
+
+	/// <summary>
+	/// Represents the mapping for the entries of the <see cref="ShipData.ShipConfiguration">ship configuration</see> of a ship.
+	/// </summary>
+	public static class ShipConfigMapping
+	{
+		public const byte ShipId = 0;
+		public const byte TotalValueCount = 1;
+		public const byte ShipModules = 2;
+		public const byte ShipUpgrades = 3;
+		public const byte ExteriorSlots = 4;
+		public const byte AutoSupplyState = 5;
+		public const byte ColorScheme = 6;
+		public const byte ConsumableSlots = 7;
+		public const byte Flags = 8;
+	}
 }

--- a/Nodsoft.WowsReplaysUnpack/Data/ReplayPlayer.cs
+++ b/Nodsoft.WowsReplaysUnpack/Data/ReplayPlayer.cs
@@ -25,51 +25,118 @@ public sealed record ReplayPlayer
 				configDumpList.Add(BitConverter.ToUInt32(byteData));
 			}
 
-			return new(ShipParamsId, configDumpList);
+			return new(ProcessShipConfigDump(configDumpList));
 		});
 	}
-	
+
+	private static IReadOnlyList<IReadOnlyList<uint>> ProcessShipConfigDump(IReadOnlyList<uint> rawConfigDump)
+	{
+		int listPosition = 0;
+		int currentLength = (int)rawConfigDump[listPosition++];
+		List<List<uint>> groupedList = new();
+		List<uint> tmpList = new();
+		int step = 0;
+		while (listPosition < rawConfigDump.Count)
+		{
+			if (currentLength == 0)
+			{
+				groupedList.Add(tmpList);
+				step++;
+				if (step is Constants.ShipConfigMapping.TotalValueCount or Constants.ShipConfigMapping.AutoSupplyState)
+				{
+					tmpList = new() { rawConfigDump[listPosition++] };
+				}
+				else
+				{
+					currentLength = (int)rawConfigDump[listPosition++];
+					tmpList = new();
+				}
+			}
+			else
+			{
+				tmpList.Add(rawConfigDump[listPosition++]);
+				currentLength--;
+			}
+		}
+			
+		groupedList.Add(tmpList);
+		return groupedList;
+	}
+
 	public IReadOnlyDictionary<string, object> Properties { get; init; } = new Dictionary<string, object>();
 
 	public uint AccountId { get; set; }
+
 	public bool AntiAbuseEnabled { get; set; }
+
 	public uint AvatarId { get; set; }
 
 	public object? CamouflageInfo { get; set; }
 
 	public uint ClanColor { get; set; }
+
 	public uint ClanId { get; set; }
+
 	public string? ClanTag { get; set; }
 
 	public ArrayList? CrewParams { get; set; }
+
 	public ArrayList? DogTag { get; set; }
+
 	public short FragsCount { get; set; }
+
 	public bool FriendlyFireEnabled { get; set; }
+
 	public uint Id { get; set; }
+
 	public bool InvitationsEnabled { get; set; }
+
 	public bool IsAbuser { get; set; }
+
 	public bool IsAlive { get; set; }
+
 	public bool IsBot { get; set; }
+
 	public bool IsClientLoaded { get; set; }
+
 	public bool IsConnected { get; set; }
+
 	public bool IsHidden { get; set; }
+
 	public bool IsLeaver { get; set; }
+
 	public bool IsPreBattleOwner { get; set; }
+
 	public bool IsTShooter { get; set; }
+
 	public short KilledBuildingsCount { get; set; }
+
 	public uint MaxHealth { get; set; }
+
 	public string Name { get; set; } = string.Empty;
+
 	public ClassDict? PlayerMode { get; set; }
+
 	public uint PreBattleIdOnStart { get; set; }
+
 	public object? PreBattleSign { get; set; }
+
 	public uint PreBattleId { get; set; }
+
 	public string Realm { get; set; } = string.Empty;
+
 	public Hashtable? ShipComponents { get; set; }
+
 	public string ShipConfigDump { get; set; } = string.Empty;
+
 	public uint ShipId { get; set; }
+
 	public uint ShipParamsId { get; set; }
+
 	public uint SkinId { get; set; }
+
 	public uint TeamId { get; set; }
+
 	public bool TtkStatus { get; set; }
 
 	public Lazy<ShipData> ShipData { get; }

--- a/Nodsoft.WowsReplaysUnpack/Data/ShipData.cs
+++ b/Nodsoft.WowsReplaysUnpack/Data/ShipData.cs
@@ -14,47 +14,47 @@ public sealed record ShipData(IReadOnlyList<IReadOnlyList<uint>> ShipConfigurati
 	/// <summary>
 	/// Gets the numeric id of the selected ship.
 	/// </summary>
-	public uint ShipId => ShipConfiguration[Constants.ShipConfigMapping.ShipId].First();
+	public uint ShipId { get; } = ShipConfiguration[Constants.ShipConfigMapping.ShipId].First();
 
 	/// <summary>
 	/// Gets the total number of values that are present in the raw data list.
 	/// Not recommended to use.
 	/// </summary>
-	public uint TotalValueCount => ShipConfiguration[Constants.ShipConfigMapping.TotalValueCount].First();
+	public uint TotalValueCount { get; } = ShipConfiguration[Constants.ShipConfigMapping.TotalValueCount].First();
 
 	/// <summary>
 	/// Gets the list of the ids of the selected ship modules.
 	/// </summary>
-	public IReadOnlyList<uint> ShipModules => ShipConfiguration[Constants.ShipConfigMapping.ShipModules];
+	public IReadOnlyList<uint> ShipModules { get; } = ShipConfiguration[Constants.ShipConfigMapping.ShipModules];
 
 	/// <summary>
 	/// Gets the list of the ids of the selected ship upgrades.
 	/// </summary>
-	public IReadOnlyList<uint> ShipUpgrades => ShipConfiguration[Constants.ShipConfigMapping.ShipUpgrades];
+	public IReadOnlyList<uint> ShipUpgrades { get; } = ShipConfiguration[Constants.ShipConfigMapping.ShipUpgrades];
 
 	/// <summary>
 	/// Gets the list of the selected exterior components.
 	/// Usually signals, but it can contain other exterior stuff as well.
 	/// </summary>
-	public IReadOnlyList<uint> ExteriorSlots => ShipConfiguration[Constants.ShipConfigMapping.ExteriorSlots];
+	public IReadOnlyList<uint> ExteriorSlots { get; } = ShipConfiguration[Constants.ShipConfigMapping.ExteriorSlots];
 
 	/// <summary>
 	/// Gets the auto supply state. It's unclear how this is calculated.
 	/// </summary>
-	public uint AutoSupplyState => ShipConfiguration[Constants.ShipConfigMapping.AutoSupplyState].First();
+	public uint AutoSupplyState { get; } = ShipConfiguration[Constants.ShipConfigMapping.AutoSupplyState].First();
 
 	/// <summary>
 	/// Gets the list of color scheme data.
 	/// </summary>
-	public IReadOnlyList<uint> ColorScheme => ShipConfiguration[Constants.ShipConfigMapping.ColorScheme];
+	public IReadOnlyList<uint> ColorScheme { get; } = ShipConfiguration[Constants.ShipConfigMapping.ColorScheme];
 
 	/// <summary>
 	/// Gets the list of the selected consumables.
 	/// </summary>
-	public IReadOnlyList<uint> ConsumableSlots => ShipConfiguration[Constants.ShipConfigMapping.ConsumableSlots];
+	public IReadOnlyList<uint> ConsumableSlots { get; } = ShipConfiguration[Constants.ShipConfigMapping.ConsumableSlots];
 
 	/// <summary>
 	/// Gets the currently mounted flags of the ship.
 	/// </summary>
-	public IReadOnlyList<uint> Flags => ShipConfiguration[Constants.ShipConfigMapping.Flags];
+	public IReadOnlyList<uint> Flags { get; } = ShipConfiguration[Constants.ShipConfigMapping.Flags];
 }

--- a/Nodsoft.WowsReplaysUnpack/Data/ShipData.cs
+++ b/Nodsoft.WowsReplaysUnpack/Data/ShipData.cs
@@ -1,23 +1,60 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace Nodsoft.WowsReplaysUnpack.Data;
 
 /// <summary>
 /// Represents the data extracted from the shipConfigDump property of a player entry in the replay.
+/// <br/>
+/// The individual lists may contain 0 values, indicating that a slot or module is either unused or not available on the ship.
 /// </summary>
-/// <param name="ShipId">The id of the ship.</param>
-/// <param name="ShipConfigurationList">A mapping of the ship configuration.</param>
-public sealed record ShipData(uint ShipId, IReadOnlyList<uint> ShipConfigurationList)
+/// <param name="ShipConfiguration">A mapping of the ship configuration.</param>
+public sealed record ShipData(IReadOnlyList<IReadOnlyList<uint>> ShipConfiguration)
 {
-	private const uint componentIdStart = 3000000000; // Player IDs end at 2.999.999.999 and apparently WG components start at 3 billion.
-	
-	private readonly Lazy<List<uint>> filteredIds = new(() => ShipConfigurationList.Where(id => id > componentIdStart).ToList());
+	/// <summary>
+	/// Gets the numeric id of the selected ship.
+	/// </summary>
+	public uint ShipId => ShipConfiguration[Constants.ShipConfigMapping.ShipId].First();
 
 	/// <summary>
-	/// Gets a filtered version of the <see cref="ShipConfigurationList"/> that only contains component IDs used by Wargaming.
-	/// Metadata like section length and other configurations are filtered out.
+	/// Gets the total number of values that are present in the raw data list.
+	/// Not recommended to use.
 	/// </summary>
-	public IReadOnlyList<uint> FilteredIds => filteredIds.Value;
+	public uint TotalValueCount => ShipConfiguration[Constants.ShipConfigMapping.TotalValueCount].First();
+
+	/// <summary>
+	/// Gets the list of the ids of the selected ship modules.
+	/// </summary>
+	public IReadOnlyList<uint> ShipModules => ShipConfiguration[Constants.ShipConfigMapping.ShipModules];
+
+	/// <summary>
+	/// Gets the list of the ids of the selected ship upgrades.
+	/// </summary>
+	public IReadOnlyList<uint> ShipUpgrades => ShipConfiguration[Constants.ShipConfigMapping.ShipUpgrades];
+
+	/// <summary>
+	/// Gets the list of the selected exterior components.
+	/// Usually signals, but it can contain other exterior stuff as well.
+	/// </summary>
+	public IReadOnlyList<uint> ExteriorSlots => ShipConfiguration[Constants.ShipConfigMapping.ExteriorSlots];
+
+	/// <summary>
+	/// Gets the auto supply state. It's unclear how this is calculated.
+	/// </summary>
+	public uint AutoSupplyState => ShipConfiguration[Constants.ShipConfigMapping.AutoSupplyState].First();
+
+	/// <summary>
+	/// Gets the list of color scheme data.
+	/// </summary>
+	public IReadOnlyList<uint> ColorScheme => ShipConfiguration[Constants.ShipConfigMapping.ColorScheme];
+
+	/// <summary>
+	/// Gets the list of the selected consumables.
+	/// </summary>
+	public IReadOnlyList<uint> ConsumableSlots => ShipConfiguration[Constants.ShipConfigMapping.ConsumableSlots];
+
+	/// <summary>
+	/// Gets the currently mounted flags of the ship.
+	/// </summary>
+	public IReadOnlyList<uint> Flags => ShipConfiguration[Constants.ShipConfigMapping.Flags];
 }

--- a/Nodsoft.WowsReplaysUnpack/Infrastructure/Blowfish.cs
+++ b/Nodsoft.WowsReplaysUnpack/Infrastructure/Blowfish.cs
@@ -50,8 +50,6 @@ Use the same mode of operation for decryption.
  * -Use a MAC to ensure that the ciphertext and IV have not been modified.
  * -Do not use the compatibility mode unless neccessary.
  */
-#nullable enable
-
 using System;
 using System.Security.Cryptography;
 using System.Text;
@@ -836,5 +834,3 @@ internal class Blowfish
 
 	#endregion
 }
-
-#nullable restore

--- a/Nodsoft.WowsReplaysUnpack/ReplayUnpacker.cs
+++ b/Nodsoft.WowsReplaysUnpack/ReplayUnpacker.cs
@@ -221,7 +221,7 @@ public class ReplayUnpacker
 				}
 			}
 		}
-		
+
 		return player;
 	}
 


### PR DESCRIPTION
This PR adds the functionality to deconstruct the list of uints retrieved from the ship config dump into mutliple lists or single values that can then be processed by a client.