### PR TITLE
Add Semaphore to address #23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   - push
   - pull_request
   - workflow_call
+  - workflow_dispatch
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,10 @@
 name: .NET Build & Test
 
 on:
-  - push
-  - pull_request
-  - workflow_call
-  - workflow_dispatch
+  push:
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -21,7 +21,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
-    - uses: dotnet/nbgv@main
+    - uses: dotnet/nbgv@v0.4.1
       id: nbgv
 
     - name: Restore dependencies

--- a/Nodsoft.WowsReplaysUnpack.Console/Program.cs
+++ b/Nodsoft.WowsReplaysUnpack.Console/Program.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Threading.Tasks;
 
 string samplePath = Path.Join(Directory.GetCurrentDirectory(), "../../../..", "Replay-Samples");
 FileStream _GetReplayFile(string name) => File.OpenRead(Path.Join(samplePath, name));
@@ -49,6 +50,12 @@ ReplayUnpackerFactory? replayUnpacker = services.GetRequiredService<ReplayUnpack
 //	Console.WriteLine($"[{GetGroupString(msg)}] {msg.EntityId} : {msg.MessageContent}");
 //}
 
+Task<UnpackedReplay>[] tasks = { };
+for (int i = 0; i < 10; i++)
+{
+	tasks.Append(Task.Run(() => replayUnpacker.GetUnpacker().Unpack(_GetReplayFile("good.wowsreplay"))));
+}
+await Task.WhenAll(tasks);
 
 var goodReplay = replayUnpacker.GetUnpacker().Unpack(_GetReplayFile("good.wowsreplay"));
 var alphaReplay = replayUnpacker.GetUnpacker().Unpack(_GetReplayFile("press_account_alpha.wowsreplay"));

--- a/Nodsoft.WowsReplaysUnpack.Tests/ReplayParsingExecutionTests.cs
+++ b/Nodsoft.WowsReplaysUnpack.Tests/ReplayParsingExecutionTests.cs
@@ -5,10 +5,6 @@ using Nodsoft.WowsReplaysUnpack.Services;
 using Xunit;
 
 
-/*
- * FIXME: Test parallelization is disabled due to a file loading issue.
- */
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
 namespace Nodsoft.WowsReplaysUnpack.Tests;
 
 /// <summary>


### PR DESCRIPTION
[The issue](https://github.com/Nodsoft/WoWS-ReplaysUnpack/issues/23) is introduced during multi-threading. The error appears to be deflation failure, potentially due to incorrect file loading. However, during my research, the deflation process seems to function correctly during multi-threading. The main issue is related to `BinaryReader`. The `decryptedStream` was only incorrect because `Decrypt()` produced corrupted data.

The next issue occured while parsing network packets.
```c#
foreach (NetworkPacketBase networkPacket in _replayDataParser.ParseNetworkPackets(replayDataStream, options))
{
    _replayController.HandleNetworkPacket(networkPacket, options);
}
```
The current solution is guarding it with a Semaphore to prevent multi-threading, because `BinaryReader`s are throwing random *end of the stream* error everywhere.

In summary, this PR addresses the issue with parallel execution. However, the program only gains a small boost of less than 10% compared to synchronous execution.

Please check [this run](https://github.com/wowsinfo/WoWS-ReplaysUnpack/actions/runs/6374401249) for the .NET Build & Test.