### PR TITLE
ignore text comments

### DIFF
--- a/Nodsoft.WowsReplaysUnpack.Console/Program.cs
+++ b/Nodsoft.WowsReplaysUnpack.Console/Program.cs
@@ -1,4 +1,6 @@
 ﻿using Nodsoft.WowsReplaysUnpack.Console.Samples.EntitySerializer;
+using Nodsoft.WowsReplaysUnpack.Console.Tests;
 
 // await new SyncTest().ExecuteAsync();
-await new EntitySerializerSample().ExecuteAsync();
+//await new EntitySerializerSample().ExecuteAsync();
+new BrokenReplayTests().Execute();

--- a/Nodsoft.WowsReplaysUnpack.Console/Tests/BrokenReplayTests.cs
+++ b/Nodsoft.WowsReplaysUnpack.Console/Tests/BrokenReplayTests.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Nodsoft.WowsReplaysUnpack.Services;
+using System.IO;
+
+namespace Nodsoft.WowsReplaysUnpack.Console.Tests;
+
+public class BrokenReplayTests
+{
+	public void Execute()
+	{
+		var services = new ServiceCollection();
+		services.AddLogging();
+		services.AddWowsReplayUnpacker();
+		var sp = services.BuildServiceProvider();
+
+		var path = @"E:\Downloads\20241104_185414_PWSB719-Niord_19_OC_prey.wowsreplay";
+		// var path =
+		// 	@"E:\Downloads\5915c052ee734ef68f0b6b0065a0fe52-20241027_003342_PHSD509-Groningen_45_Zigzag.wowsreplay";
+		var fs = File.OpenRead(path);
+
+		var replay = sp.GetRequiredService<IReplayUnpackerFactory>()
+			.GetUnpacker()
+			.Unpack(fs);
+		
+		System.Console.WriteLine();
+	}
+}

--- a/Nodsoft.WowsReplaysUnpack.Core/Definitions/EntityDefinition.cs
+++ b/Nodsoft.WowsReplaysUnpack.Core/Definitions/EntityDefinition.cs
@@ -9,7 +9,7 @@ namespace Nodsoft.WowsReplaysUnpack.Core.Definitions;
 public sealed class EntityDefinition : BaseDefinition
 {
 	private const string ENTITY_DEFS = "entity_defs";
-	
+
 	private List<EntityMethodDefinition> CellMethods { get; set; } = new();
 	// public List<EntityMethodDefinition> BaseMethods { get; set; } = new();
 
@@ -18,8 +18,10 @@ public sealed class EntityDefinition : BaseDefinition
 	/// </summary>
 	public List<EntityMethodDefinition> ClientMethods { get; private set; } = new();
 
-	private EntityDefinition(Version clientVersion, IDefinitionStore definitionStore, string name) 
-		: base(clientVersion, definitionStore, name, ENTITY_DEFS) { }
+	private EntityDefinition(Version clientVersion, IDefinitionStore definitionStore, string name)
+		: base(clientVersion, definitionStore, name, ENTITY_DEFS)
+	{
+	}
 
 	public static EntityDefinition Create(Version clientVersion, IDefinitionStore definitionStore, string name)
 	{
@@ -28,11 +30,12 @@ public sealed class EntityDefinition : BaseDefinition
 		{
 			throw new Exception("XmlDocument has to be set");
 		}
+
 		definition.ParseDefinitionFile(definition.XmlDocument);
 		definition.XmlDocument = null; // Xml does not need to stay in memory
 		return definition;
 	}
-	
+
 	/// <summary>
 	/// Parses a .def file for the entity definition.
 	/// </summary>
@@ -57,6 +60,8 @@ public sealed class EntityDefinition : BaseDefinition
 
 		foreach (XmlNode node in methodsNode.ChildNodes())
 		{
+			if (node is not XmlElement)
+				continue;
 			methods.Add(new(ClientVersion, DefinitionStore, node));
 		}
 	}


### PR DESCRIPTION
WG started adding random todo comments into the xml which broke the parsing as it was adding the comments todo leading to incorrect method indexes.

Filtering out enything not an XMLElement now (comments are XmlText)